### PR TITLE
Media Query Updates to Forms and Footer and Nav Touch Ups

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -71,15 +71,14 @@ body {
 .login-container {
   width: 40vw;
   margin-top: var(--spacing-five);
-  border: 3px var(--light-green) solid;
   border-radius: 15px;
-  transform: translate(0%, 20%);
-  background-image: linear-gradient(200deg, rgba(22, 110, 243, .8)15%, rgba(226, 204, 170, 1)45%, rgba(49, 115, 18, .6)95%);
+  margin-top: 10vh !important;
+  background-image: linear-gradient(180deg, rgba(22, 110, 243, .8)15%, rgba(6, 186, 236, .7)65%, rgba(49, 115, 18, .6)95%)
 }
 
 .login-link,
 .signup-link {
-  margin-top: var(--spacing-two);
+  margin-top: var(--spacing-five) !important;
 }
 
 .login-link a,
@@ -91,17 +90,18 @@ body {
 .login-link a:hover,
 .signup-link a:hover {
   text-decoration: none;
-  color: var(--dark-blue);
+  color: var(--light-green);
 }
 
 .signup-header,
 .login-header {
-transform: translate(40%, 0%);
+  margin-left: 18vw;
 }
 
 .signup-form,
 .login-form {
-  transform: translate(25%, 0%);
+  margin-top: 7vh;
+  margin-left: 15vw;
 }
 
 .form-div label {
@@ -114,7 +114,21 @@ transform: translate(40%, 0%);
 
 .signup-btn,
 .login-btn {
-  transform: translate(50%, 0%);
+  margin-bottom: var(--spacing-five);
+  margin-left: 2vw;
+}
+
+@media screen and (max-width: 1285px) {
+  .login-form,
+  .signup-form {
+    margin-left: 12vw;
+  }
+
+  .signup-header,
+  .login-header {
+    margin-top: 7vh;
+    margin-left: 15vw;
+  }
 }
 
 @media screen and (max-width: 775px) {
@@ -122,4 +136,43 @@ transform: translate(40%, 0%);
   .login-container {
     width: 80vw;
   }
+
+  .login-form,
+  .signup-form {
+    margin-left: 25vw;
+  }
+
+  .signup-header,
+  .login-header {
+    margin-top: 7vh;
+    margin-left: 32vw;
+  }
+
+  .signup-btn,
+  .login-btn {
+  margin-bottom: 10vw;
+  margin-left: 6vw;
+}
+}
+
+@media screen and (max-width: 525px) {
+
+  .login-form,
+  .signup-form {
+    margin-top: 0vh;
+    margin-left: 10vw;
+    margin-bottom: 10vh;
+  }
+
+  .signup-header,
+  .login-header {
+    margin-top: 7vh;
+    margin-left: 25vw;
+  }
+
+  .signup-btn,
+  .login-btn {
+  margin-bottom: 10vw;
+  margin-left: 13vw;
+}
 }

--- a/client/src/components/Create-activity/Create-activity.css
+++ b/client/src/components/Create-activity/Create-activity.css
@@ -13,24 +13,34 @@
 
  .create-activity-form {
    display: flex;
-   position: relative;
    margin-top: var(--spacing-five);
-   width: 30vw;
-   border: 3px var(--light-green) solid;
+   margin-bottom: var(--spacing-five);
+   margin-left: 25vw;
+   width: 60vw;
    border-radius: 15px;
-   transform: translate(120%, -20%);
-   background-image: linear-gradient(200deg, rgba(22, 110, 243, .8)15%, rgba(226, 204, 170, 1)45%, rgba(49, 115, 18, .6)95%)
+   background-image: linear-gradient(180deg, rgba(22, 110, 243, .8)15%, rgba(6, 186, 236, .7)65%, rgba(49, 115, 18, .6)95%)
  }
 
- .activity-form {
-   transform: translate(20%, -0%);
+ .activity-form h3 {
    padding: 40px;
+   margin-left: 25vw;
+}
+
+ .activity-form input,
+ .activity-form textarea {
+    width: 35vw;
+    margin-left: 12.5vw;
+ }
+
+ .activity-form button {
+    margin-bottom: var(--spacing-two);
+    margin-left: 25vw;
  }
 
  .activity-text {
    width: 15em;
    height: 5em;
-   background-color: #F2F2F2;
+   background-color: #f2f2f2;
    border:none;
    border-radius:3px;
    margin-top:3px;
@@ -56,18 +66,30 @@
 }
 
 .delete-btn {
-   height: 5vh;
+   position: absolute;
+   z-index: 9999;
+   height: 2em;
    width: auto;
    font-size: 1.5em;
-   transform: translate(1020%, -1500%);
+   margin-left: 27vw;
    color: var(--dark-green);
 }
 
 .add-activity-btn {
-   transform: translate(300%, -150%);
    width: fit-content;
    text-decoration: none;
    color: var(--dark-blue);
+}
+
+.full-itinerary-btn {
+   width: fit-content;
+   margin-left: 8vw;
+   background-color: white;
+   color: var(--light-blue);
+}
+
+.full-itinerary-btn:hover {
+   background-color: var(--dark-blue);
 }
 
 .add-activity-btn:hover {
@@ -75,11 +97,108 @@
    color: var(--dark-blue);
 }
 
-/* .center {
-   display: flex;
-   justify-content: 'center';
-   align-items: 'center';
-} */
+.activity-buttons {
+   margin-left: 40vw;
+}
+
+@media screen and (max-width: 1285px) {
+   .activity-buttons {
+      margin-left: 27vw;
+   }
+
+   .create-activity-form {
+      width: 80vw;
+      transform: translate(0%, 0%);
+      margin-left: 11vw;
+   }
+
+   .activity-form h3 {
+      margin-left: 28vw;
+   }
+
+   .activity-form button {
+      margin-left: 30vw;
+   }
+
+   .activity-form input,
+   .activity-form textarea {
+     width: 50vw;
+     margin-left: 15vw;
+   }
+
+   .delete-btn {
+      margin-left: 13vw;
+   }
+}
+
+@media screen and (max-width: 775px) {
+   .activity-buttons {
+      display: flex;
+      width: fit-content;
+      margin-left: 20vw;
+   }
+
+   .activity-buttons h2 {
+      font-size: 1.5em;
+   }
+
+   .create-activity-form {
+      width: 80vw;
+      transform: translate(0%, 0%);
+      margin-left: 10vw;
+      margin-bottom: var(--spacing-five);
+   }
+
+   .create-activity-form h3 {
+      margin-left: 22vw;
+   }
+
+   .activity-form {
+      margin-left: 2vw;
+      width: 70vw;
+   }
+
+   .activity-form input,
+   .activity-form textarea {
+      width: 65vw;
+      transform: translate(0%, 0%);
+      margin-left: 5vw;
+   }
+
+   .activity-form button {
+      margin-left: 23vw;
+   }
+
+   .delete-btn {
+      z-index: 9999;
+      margin-left: 14vw;
+   }
+
+   .add-activity-btn:hover,
+   .full-itinerary-btn:hover {
+      background-color: white;
+   }
+
+}
+
+@media screen and (max-width: 525px) {
+   .create-activity-form button {
+      margin-left: 13vw;
+   }
+
+   .full-itinerary-btn {
+      width: fit-content;
+   }
+
+   .add-activity-btn {
+      width: fit-content;
+   }
+
+   .activity-buttons h2 {
+      font-size: 1em;
+      margin-left: -10vw;
+   }
+}
 
 
 

--- a/client/src/components/Create-activity/Create-activity.js
+++ b/client/src/components/Create-activity/Create-activity.js
@@ -108,7 +108,6 @@ const CreateActivity = (props) => {
         <button className="btn activity-submit">
           Submit
         </button>
-        <Link to={`/itinerary/${itineraryId}`}><button>View Full Itinerary</button></Link>
       </form>
     </div>
     </section>

--- a/client/src/components/Create-activity/CreateActivityContainer.js
+++ b/client/src/components/Create-activity/CreateActivityContainer.js
@@ -1,11 +1,14 @@
 import React, { useState, Fragment } from "react";
 import CreateActivity from './Create-activity'
-import { faTrashAlt, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import ReactDOM from "react-dom";
+import { Link } from 'react-router-dom';
+import { faTrashAlt, faPlusCircle, faClipboardList } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import './Create-activity.css';
 
 const CreateActivityContainer = (props) => {
+  const itineraryId = localStorage.getItem("itineraryId");
   const [inputFields, setInputFields] = useState([
     {location:'', date:'', timeFrom:'', timeTo:'', notes:'', itineraryId:''}
   ]);
@@ -24,17 +27,21 @@ const CreateActivityContainer = (props) => {
 
   return (
     <>
-      <button
-                  className="btn btn-link add-activity-btn"
-                  type="button"
-                  onClick={() => handleAddFields()}
-                >
-                  <h2><FontAwesomeIcon icon={faPlusCircle}/> Add Activity</h2>
-                </button>
+    <div className="activity-buttons">
+    <button
+        className="btn btn-link add-activity-btn"
+        type="button"
+        onClick={() => handleAddFields()}
+      >
+        <h2><FontAwesomeIcon icon={faPlusCircle}/> Add Activity</h2>
+      </button>
+    <Link to={`/itinerary/${itineraryId}`}><button className="full-itinerary-btn btn"><h2><FontAwesomeIcon icon={faClipboardList}/> View Full Itinerary</h2></button></Link>
+    </div>
+
         <div className="center">
           {inputFields.map((inputField, index) => (
             <Fragment key={`${inputField}~${index}`}>
-              <CreateActivity/>
+              <div className="f-container">
               <button
                 className="btn delete-btn"
                 type="button"
@@ -42,7 +49,8 @@ const CreateActivityContainer = (props) => {
               >
                 <FontAwesomeIcon icon={faTrashAlt}/>
               </button>
-
+              <CreateActivity/>
+              </div>
             </Fragment>
           ))}
         </div>

--- a/client/src/components/CreateItinerary/CreateItinerary.css
+++ b/client/src/components/CreateItinerary/CreateItinerary.css
@@ -18,21 +18,25 @@
 
 .c-create-itinerary-form {
   margin-top: var(--spacing-five);
+  margin-bottom: 10vh;
   width: 60vw;
-  border: 3px var(--light-green) solid;
+  height: 60vh;
   border-radius: 15px;
   transform: translate(35%, -0%);
-  background-image: linear-gradient(200deg, rgba(22, 110, 243, .8)15%, rgba(226, 204, 170, 1)45%, rgba(49, 115, 18, .6)95%)
+  background-image: linear-gradient(180deg, rgba(22, 110, 243, .8)15%, rgba(6, 186, 236, .7)65%, rgba(49, 115, 18, .6)95%)
 }
 
 .page-header {
-  transform: translate(40%, -0%);
+  margin-left: 43vw;
+}
+
+.itinerary-submit {
+  margin-left: 14vw !important;
 }
 
 .btn {
   margin-top: 30px;
   width: 6em;
-  transform: translate(100%, -0%);
   transition: .8s;
 }
 
@@ -41,33 +45,73 @@
 }
 
 .itinerary-form {
-  transform: translate(30%, -0%);
   padding: 40px;
+  margin-left: 10vw;
+}
+
+.itinerary-form button {
+  margin-left: 9vw;
+}
+
+.itinerary-form input {
+  margin-top: 5vh;
+  width: 30vw;
 }
 
 .itinerary-text {
-  width:20vw;
+  width: 20vw;
   background-color: #F2F2F2;
   border:none;
   border-radius:3px;
-  margin-top:3px;
+  margin-top: 3px;
+}
+
+@media screen and (max-width: 1285px) {
+  .page-header {
+    margin-left: 38vw;
+  }
+
+  .itinerary-form button {
+    margin-left: 10vw;
+  }
 }
 
 @media screen and (max-width: 775px) {
   .page-header {
-    transform: translate(70%, 20%);
+    margin-left: 30vw;
     width: fit-content;
   }
 
   .itinerary-form {
-    transform: translate(10%, 0%);
+    margin-left: 4vw;
+  }
+
+  .itinerary-form button {
+    margin-left: 2vw;
   }
 }
 
 @media screen and (max-width: 525px) {
   .c-create-itinerary-form {
     width: 90vw;
-    transform: translate(5%, 0%);
+    height: 50vh;
+    margin-left: 5vw;
+    transform: translate(0%, 0%);
+  }
+
+  .page-header {
+    margin-left: -3vw;
+  }
+
+  .itinerary-form input {
+    margin-top: 2vh;
+    margin-left: -10vw;
+    width: 70vw;
+  }
+
+  .itinerary-submit {
+    margin-left: 20vw !important;
+    transform: translate(0%, 0%);
   }
 
   .page-header {

--- a/client/src/components/CreateItinerary/CreateItinerary.js
+++ b/client/src/components/CreateItinerary/CreateItinerary.js
@@ -133,7 +133,7 @@ const CreateItinerary = (props) => {
             </div>
         </ul>
         <button 
-                className='btn'
+                className='btn itinerary-submit'
                 onClick={handleFormSubmit}
             >
               Submit

--- a/client/src/components/Footer/index.css
+++ b/client/src/components/Footer/index.css
@@ -13,11 +13,11 @@
 
 /* Footer Styling */
 footer {
+    clear: both;
+    height: 40px;
     bottom: 0;
-    position: absolute;
-    padding: 10px 0;
-    padding-top: 20px;
-    margin-top: 20px;
+    position: fixed;
+    margin-top: 10vh;
     width: 100vw;
     background-image: linear-gradient(145deg, rgba(22, 110, 243, .5)15%, rgba(36, 186, 236, 1)45%, rgba(22, 110, 243, .6)85%)
 }
@@ -34,7 +34,7 @@ footer ul {
 .footer-link {
     color:var(--dark-blue);
     text-decoration: none;
-    font-size: 2em;
+    font-size: 1.5em;
 }
 
 .footer-link:hover {
@@ -46,19 +46,17 @@ footer ul {
 
 @media screen and (max-width: 775px) {
     .footer-item {
-        margin-left: 7%;
+        margin-left: 10%;
     }
 }
 
 @media screen and (max-width: 525px) {
-    footer {
-        height: 7vh;
-    }
 
     .footer-item {
         margin-bottom: 10px;
         justify-content: space-around;
         bottom: 0;
+        margin-left: 6%;
     }
 
     .footer-link {

--- a/client/src/components/Nav/Nav.css
+++ b/client/src/components/Nav/Nav.css
@@ -17,7 +17,7 @@ header {
     background-position: 10% 120%;
     background-attachment: fixed;
     z-index: 9999;
-    height: 10vh;
+    height: auto;
     width: 100%;
     font-family: 'Montserrat', sans-serif;
 }
@@ -38,7 +38,6 @@ header nav ul li :hover,
 header nav ul li :hover,
 header h1 :hover {
     color: var(--dark-cream);
-    /* border-radius: 15px; */
     text-shadow: none;
     text-decoration: none;
     transition: .4s;
@@ -63,6 +62,7 @@ nav li {
 .logo-img {
     background-color: rgba(0, 0, 0, .6);
     height: 1.2em;
+    margin-bottom: var(--spacing-one);
     border-radius: 15px;
 }
 
@@ -140,9 +140,16 @@ nav li {
     }
 
     header nav {
-      font-size: 1.6em;
-      transform: translate(5%, 0%);
+      font-size: 1.3em;
+      width: 100vw;
     }
+
+  .logged-in {
+      margin-left: 10%;
+    }
+  .logged-out {
+    margin-left: 21%!important;
+  }
 
     .logo-img:hover {
       background-color: rgba(0, 0, 0, .6);
@@ -150,6 +157,7 @@ nav li {
   }
 
   @media screen and (max-width: 525px) {
+
     .logo-img {
       height: 1em;
       transform: translate(3%,0%);
@@ -157,7 +165,17 @@ nav li {
     }
 
     header nav {
+      font-size: 1em;
+    }
+
+
+    .logged-out {
+      margin-left: 3% !important;
+    }
+
+    .logged-in {
       transform: translate(0%, 0%);
       margin-left: var(--spacing-five);
     }
+
   }

--- a/client/src/components/Nav/index.js
+++ b/client/src/components/Nav/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { faCompass } from '@fortawesome/free-solid-svg-icons';
+import { faCompass} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Auth from "../../utils/auth";
 import { Link } from "react-router-dom";
@@ -9,7 +9,7 @@ function Nav() {
   function showNavigation() {
     if (Auth.loggedIn()) {
       return (
-        <ul className="flex-row">
+        <ul className="flex-row logged-in">
           <li className="mx-1">
             <a href="/donate">
               Donate
@@ -34,7 +34,7 @@ function Nav() {
       );
     } else {
       return (
-        <ul className="flex-row">
+        <ul className="flex-row logged-out">
           <li className="mx-1">
             <a href="/donate">
               Donate


### PR DESCRIPTION
Changed the gradient design of the forms and removed the border. Removed all transform: translate() stylings because they were interferring with media queries. Updated the footer to be sticky to the bottom of the webpage and be smaller so it does not obstruct views. In order to avoid view obstruction from footer, always add a margin-bottom styling to whatever element is last on the page. Update the login and sign up forms with mediq query styling to suit smaller screens, tablets, and smartphones. CreateActivity and CreateItinerary forms have also been updated with laptop screens, tablets and smartphone media queries.